### PR TITLE
update fit bloc booking link

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -14,7 +14,7 @@ export const gymBookingLinks = {
   lighthouse: 'https://www.lighthouseclimbing.com/',
   'boulder-world':
     'https://www.picktime.com/566fe29b-2e46-4a73-ad85-c16bfc64b34b',
-  fitbloc: 'https://fitbloc.com/booking/',
+  fitbloc: 'https://fitbloc.com/book-a-slot/#gymentry',
   'the-rock-school': 'https://therockschool.sg/schedule/',
   'boulder-planet': 'https://www.boulderplanet.sg/bookings',
   'boulder-movement-downtown': 'https://www.boulderm.com/register',


### PR DESCRIPTION
Just a minor fix for Fit Bloc's booking link, the current link leads to a 404 page.

<img width="1272" alt="Screenshot 2022-01-15 at 6 19 32 PM" src="https://user-images.githubusercontent.com/9312956/149618297-5a3471a0-be6b-42c6-aca6-29c04bd92372.png">
